### PR TITLE
refactor: standardize naming conventions for dialog components across…

### DIFF
--- a/libs/src/hooks/useDialog.tsx
+++ b/libs/src/hooks/useDialog.tsx
@@ -3,7 +3,7 @@ import { useState, useCallback, ReactNode } from 'react';
 
 interface DialogState {
   isOpen: boolean;
-  title: React.ReactNode;
+  header: React.ReactNode;
   content: React.ReactNode;
   onOpen?: () => void;
   onClose?: () => void;
@@ -11,31 +11,31 @@ interface DialogState {
 
 export const useDialog = ({
   isOpen,
-  title,
+  header,
   content,
   onOpen,
   onClose,
 }: {
   isOpen: boolean;
-  title: ReactNode;
+  header: ReactNode;
   content: ReactNode;
   onOpen?: () => void;
   onClose?: () => void;
 }) => {
   const [dialogState, setDialogState] = useState<DialogState>({
     isOpen,
-    title,
+    header,
     content,
   });
 
   const openDialog = useCallback(() => {
     setDialogState({
       isOpen: true,
-      title,
+      header,
       content,
     });
     onOpen && onOpen();
-  }, [content, title]);
+  }, [content, header]);
 
   const closeDialog = useCallback(() => {
     setDialogState((prev) => ({
@@ -46,7 +46,7 @@ export const useDialog = ({
   }, []);
 
   return {
-    ...dialogState, // 包含 isOpen, title, content
+    ...dialogState, // 包含 isOpen, header, content
     openDialog,
     closeDialog,
   };

--- a/libs/src/style/component/element/_accordion.scss
+++ b/libs/src/style/component/element/_accordion.scss
@@ -2,7 +2,7 @@
   interpolate-size: allow-keywords;
 }
 
-.accordion {
+.ded-accordion {
   list-style: none;
 
   &-item {
@@ -28,8 +28,8 @@
     }
   }
 
-  details {
-    .detail-title {
+  .ded-accordion-detail {
+    .ded-accordion-title {
       display: flex;
       justify-content: space-between;
       align-items: center;

--- a/libs/src/style/component/element/_divider.scss
+++ b/libs/src/style/component/element/_divider.scss
@@ -5,6 +5,7 @@
   --line-weight: 2px;
   --line-style: solid;
   display: flex;
+  min-height: 5em;
 }
 
 /*--- Divider 方向 ---*/

--- a/libs/src/ui/element/accordion/accordion-item.tsx
+++ b/libs/src/ui/element/accordion/accordion-item.tsx
@@ -63,25 +63,25 @@ export const AccordionItem: React.FC<AccordionProps> = ({
   }, []);
 
   return (
-    <li className="accordion-item">
+    <li className="ded-accordion-item">
       <details
         onToggle={(e) => {
           setIsOpen((e.target as HTMLDetailsElement).open);
         }}
         open={isOpen}
-        className={`detail ${className}`}
+        className={`ded-accordion-detail ${className}`}
       >
-        <summary className="detail-title">
+        <summary className="ded-accordion-title">
           <span>{label}</span>
           <div
-            className={`${
-              isOpen ? 'accordion-item-open' : 'accordion-item-close'
+            className={`ded-icon-medium ${
+              isOpen ? 'ded-accordion-item-open' : 'ded-accordion-item-close'
             }`}
           >
             <ArrowDownIcon width={20} height={20} />
           </div>
         </summary>
-        <div className="detail-content">
+        <div className="ded-detail-content">
           <p>{content}</p>
         </div>
       </details>

--- a/libs/src/ui/element/accordion/accordion.tsx
+++ b/libs/src/ui/element/accordion/accordion.tsx
@@ -12,16 +12,18 @@ export const Accordion: React.FC<AccordionProps> = ({
   className = '',
 }) => {
   return (
-    <ul className={`accordion ${className}`}>
-      {dataSource.map((item) => (
-        <AccordionItem
-          key={item.id}
-          label={item.label}
-          content={item.detail}
-          isOpenAll={isOpenAll}
-        />
-      ))}
-    </ul>
+    <div className="ded-accordion-container">
+      <ul className={`ded-accordion ${className}`}>
+        {dataSource.map((item) => (
+          <AccordionItem
+            key={item.id}
+            label={item.label}
+            content={item.detail}
+            isOpenAll={isOpenAll}
+          />
+        ))}
+      </ul>
+    </div>
   );
 };
 export default Accordion;

--- a/libs/src/ui/mask.tsx
+++ b/libs/src/ui/mask.tsx
@@ -6,7 +6,11 @@ export interface MaskProps {
   children: ReactNode;
 }
 
-export const Mask: React.FC<MaskProps> = ({ className, onClose, children }) => {
+export const Mask: React.FC<MaskProps> = ({
+  className = '',
+  onClose,
+  children,
+}) => {
   return (
     <div className={`mask-overlay ${className}`} onClick={onClose}>
       {children}/

--- a/libs/src/ui/module/dialog/dialog.stories.tsx
+++ b/libs/src/ui/module/dialog/dialog.stories.tsx
@@ -41,7 +41,7 @@ export default {
       },
     },
     footer: {
-      description: '底部',
+      description: '附註',
       table: {
         category: 'SLOTS',
       },
@@ -98,9 +98,9 @@ export default {
 type Story = StoryObj<typeof Dialog>;
 
 const DemoWithHook = (args: Story['args']) => {
-  const { isOpen, title, content, openDialog, closeDialog } = useDialog({
+  const { isOpen, header, content, openDialog, closeDialog } = useDialog({
     isOpen: args?.isOpen || false,
-    title: <Title level={3}>Title</Title>,
+    header: <Title level={3}>Title</Title>,
     content: <p>Content</p>,
   });
 
@@ -123,7 +123,7 @@ const DemoWithHook = (args: Story['args']) => {
         isOpen={isOpen}
         hasClose={args?.hasClose || false}
         onClose={closeDialog}
-        title={title}
+        header={header}
         content={content}
         footer={
           <>
@@ -149,12 +149,12 @@ export const Default: Story = {
   args: {
     isOpen: true,
     hasClose: false,
-    title: 'Title',
+    header: 'Title',
     content: 'Content',
     onClose: () => window.alert('close'),
   },
   render(args) {
-    const { hasClose, title, content, onClose, className } = args;
+    const { hasClose, header, content, onClose, className } = args;
     return (
       <div
         className={`dialog-content ${className}`}
@@ -165,7 +165,7 @@ export const Default: Story = {
             <CloseIcon width={20} height={20} />
           </button>
         )}
-        <div className="dialog-header">{title}</div>
+        <div className="dialog-header">{header}</div>
         <div className="dialog-body">{content}</div>
         <div className="dialog-footer">
           <Button
@@ -186,9 +186,7 @@ export const Default: Story = {
 
 export const Demo: Story = {
   name: '互動模式',
-  args: {
-    className: '',
-  },
+  args: {},
   render(args) {
     return <DemoWithHook {...args} />;
   },

--- a/libs/src/ui/module/dialog/dialog.tsx
+++ b/libs/src/ui/module/dialog/dialog.tsx
@@ -8,7 +8,7 @@ export interface DialogProps {
   isOpen: boolean;
   hasClose?: boolean;
   onClose?: () => void;
-  title?: React.ReactNode;
+  header?: React.ReactNode;
   content: React.ReactNode;
   footer?: React.ReactNode;
   className?: string;
@@ -18,7 +18,7 @@ export const Dialog: React.FC<DialogProps> = ({
   isOpen = false,
   hasClose = false,
   onClose,
-  title = 'Title',
+  header = 'Title',
   content = 'Content',
   footer,
   className = '',
@@ -36,7 +36,7 @@ export const Dialog: React.FC<DialogProps> = ({
                 <CloseIcon width={20} height={20} />
               </button>
             )}
-            <div className="dialog-header">{title}</div>
+            <div className="dialog-header">{header}</div>
             <div className="dialog-body">{content}</div>
             <div className="dialog-footer">{footer}</div>
           </div>


### PR DESCRIPTION
… codebase

- Change the Dialog component prop `title` to `header` for consistency with `useDialog` component
- Update the class name from `.accordion` to `.ded-accordion` in `_accordion.scss`
- Add a `min-height` style property to the divider element
- Rename the class from `accordion-item` to `ded-accordion-item` in `accordion-item.tsx`
- Change the dialog story description from "底部" to "附註"