### PR TITLE
refactor: refactor dialog component's header usage in Storybook

### DIFF
--- a/libs/src/ui/module/dialog/dialog.stories.tsx
+++ b/libs/src/ui/module/dialog/dialog.stories.tsx
@@ -28,7 +28,7 @@ export default {
         category: 'PROPS',
       },
     },
-    title: {
+    header: {
       description: '標題',
       table: {
         category: 'SLOTS',


### PR DESCRIPTION
- Change the `title` key to `header` in the storybook file for dialog component.