### PR TITLE
feat: refactor input value handling in authentication flow

### DIFF
--- a/.github/workflows/demo-github-action.yaml
+++ b/.github/workflows/demo-github-action.yaml
@@ -38,3 +38,13 @@ jobs:
           publish_dir: ./dist/storybook
           user_name: 'github-actions[bot]'
           user_email: 'github-actions[bot]@users.noreply.github.com'
+
+  publish-package:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Publish Package 🚀
+        run: npm publish

--- a/libs/src/hooks/useInput.tsx
+++ b/libs/src/hooks/useInput.tsx
@@ -1,11 +1,11 @@
 import { useState, useEffect, ChangeEventHandler } from 'react';
 
 export const useInput = (
-  initValue: string,
+  currValue: string,
   type: string,
   onChange: ChangeEventHandler<HTMLInputElement> | undefined
 ) => {
-  const [value, setValue] = useState(initValue);
+  const [value, setValue] = useState(currValue);
   const [inputType, setInputType] = useState(type);
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -26,8 +26,8 @@ export const useInput = (
   }, [type]);
 
   useEffect(() => {
-    setValue(initValue);
-  }, [initValue]);
+    setValue(currValue);
+  }, [currValue]);
 
   return {
     inputType,

--- a/libs/src/style/component/element/_progress.scss
+++ b/libs/src/style/component/element/_progress.scss
@@ -68,7 +68,6 @@
 
 // 後續要確認百分比間距是否正確
 .ded-progress-line-label {
-  width: calc(3ch + 1em);
   font-size: 14px;
 }
 

--- a/libs/src/style/component/element/_tag.scss
+++ b/libs/src/style/component/element/_tag.scss
@@ -12,6 +12,10 @@
   border-radius: $radius;
   padding-inline: 24px;
 
+  &:hover:has(.ded-tag-close) {
+    padding-inline: 16px 32px;
+  }
+
   &-text {
     display: flex;
     align-items: center;
@@ -24,17 +28,18 @@
     align-items: center;
     width: 18px;
     height: 18px;
+    margin-right: 2px;
   }
 
   &:hover {
     .ded-tag-close {
       display: block;
+      right: 12px;
     }
   }
 
   &-close {
     position: absolute;
-    right: 4px;
     width: 18px;
     height: 18px;
     cursor: pointer;

--- a/libs/src/ui/element/checkbox/checkbox.stories.tsx
+++ b/libs/src/ui/element/checkbox/checkbox.stories.tsx
@@ -20,7 +20,7 @@ export default {
       },
       required: true,
     },
-    initValue: {
+    currValue: {
       description: '選中的項目',
       table: {
         category: 'PROPS',
@@ -62,7 +62,7 @@ export default {
   },
   args: {
     dataSource: options,
-    initValue: ['option1', 'option3'],
+    currValue: ['option1', 'option3'],
     direction: 'row',
     size: 'medium',
     className: '',

--- a/libs/src/ui/element/checkbox/checkbox.tsx
+++ b/libs/src/ui/element/checkbox/checkbox.tsx
@@ -7,14 +7,14 @@ import { getCombinedClassName } from '@src/utils/string';
  *
  * @property {('primary' | 'secondary' | 'neutral' | 'info' | 'success' | 'warning' | 'error')} [themeColor] - 選擇框的主題顏色。
  * @property {{ label: string; value: string; isDisabled: boolean }[]} [dataSource] - 選項的陣列，每個選項包含標籤和值。
- * @property {string[]} [initValue] - 初始選中的值。
+ * @property {string[]} [currValue] - 初始選中的值。
  * @property {('row' | 'column')} [direction] - 選項排列的方向，可以是 'row' 或 'column'。
  * @property {string} [className] - 自訂的 CSS 類名。
  * @property {(value: string[]) => void} [onChange] - 當選中的值改變時的回調函數。
  */
 export interface CheckboxProps {
   dataSource: { label: string; value: string; isDisabled: boolean }[];
-  initValue: string[];
+  currValue: string[];
   direction?: 'row' | 'column';
   size?: 'small' | 'medium' | 'large';
   className?: string;
@@ -27,7 +27,7 @@ export interface CheckboxProps {
  * @param {CheckboxProps} props - Checkbox 元件的屬性
  * @param {string} [props.themeColor='primary'] - 主題顏色
  * @param {Array} props.dataSource - 選項資料來源
- * @param {Array} [props.initValue=[]] - 初始選中的值
+ * @param {Array} [props.currValue=[]] - 初始選中的值
  * @param {string} [props.direction='row'] - 排列方向 ('row' 或 'column')
  * @param {string} [props.className] - 自訂樣式類別
  * @param {Function} [props.onChange] - 當選項變更時的回呼函數
@@ -36,13 +36,13 @@ export interface CheckboxProps {
  */
 export const Checkbox: React.FC<CheckboxProps> = ({
   dataSource,
-  initValue,
+  currValue,
   direction = 'row',
   size = 'medium',
   className = '',
   onChange,
 }: CheckboxProps) => {
-  const [currOptions, setCurrOptions] = useState<string[]>(initValue);
+  const [currOptions, setCurrOptions] = useState<string[]>(currValue);
 
   const handleChange = (value: string, checked: boolean) => {
     const updatedOptions = checked

--- a/libs/src/ui/element/date-picker/date-picker.tsx
+++ b/libs/src/ui/element/date-picker/date-picker.tsx
@@ -1,5 +1,5 @@
 import 'vanillajs-datepicker/css/datepicker-foundation.css';
-import React, { useEffect, useRef, forwardRef } from 'react';
+import React, { useEffect, useRef, forwardRef, useState } from 'react';
 import { Datepicker, DateRangePicker } from 'vanillajs-datepicker';
 import { Input } from '@src/ui';
 import { SvgCalendar } from '@src/assets/icons';
@@ -25,9 +25,14 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(
     },
     ref
   ) => {
+    const [currValue, setCurrValue] = useState(value);
     const datepickerRef = useRef<Datepicker | DateRangePicker | null>(null);
     const inputRef = useRef<HTMLInputElement>(null);
     const divRangeRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+      setCurrValue(value);
+    }, [value]);
 
     useEffect(() => {
       const inputElement =
@@ -49,6 +54,7 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(
         inputElement.addEventListener('changeDate', (e: any) => {
           if (onChange) {
             onChange(e.target.value);
+            setCurrValue(e.target.value);
           }
         });
       }
@@ -64,6 +70,7 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(
         divRangeElement.addEventListener('changeDate', (e: any) => {
           if (onChange) {
             onChange(e.target.value);
+            setCurrValue(e.target.value);
           }
         });
       }
@@ -79,7 +86,7 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(
           <div className="ded-date-pick-range" ref={ref || divRangeRef}>
             <Input
               placeholder="Start Date"
-              initValue={value}
+              currValue={currValue}
               prefix={<SvgCalendar />}
               type="text"
               onChange={() => ({})}
@@ -87,7 +94,7 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(
             />
             <Input
               placeholder="End Date"
-              initValue={value}
+              currValue={currValue}
               prefix={<SvgCalendar />}
               type="text"
               onChange={() => ({})}
@@ -95,15 +102,17 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(
             />
           </div>
         ) : (
-          <Input
-            ref={ref || inputRef}
-            placeholder={placeholder}
-            initValue={value}
-            prefix={<SvgCalendar />}
-            type="text"
-            onChange={() => ({})}
-            className={className}
-          />
+          <>
+            <Input
+              ref={ref || inputRef}
+              placeholder={placeholder}
+              currValue={currValue}
+              prefix={<SvgCalendar />}
+              type="text"
+              onChange={() => ({})}
+              className={className}
+            />
+          </>
         )}
       </div>
     );

--- a/libs/src/ui/element/divider/divider.stories.tsx
+++ b/libs/src/ui/element/divider/divider.stories.tsx
@@ -1,5 +1,7 @@
 import { Meta, StoryContext, StoryObj } from '@storybook/react';
 import { Divider } from './divider';
+import { log } from 'console';
+import { p } from 'react-router/dist/development/fog-of-war-DLtn2OLr';
 
 export default {
   title: 'Component/Divider',
@@ -70,6 +72,21 @@ export default {
     className: '',
     children: 'Divider',
   },
+  decorators: [
+    (Story, { args: { direction } }) => {
+      console.log(direction);
+      return (
+        <div
+          style={{
+            display: `${direction === 'horizontal' ? 'block' : 'flex'}`,
+            height: '100px',
+          }}
+        >
+          <Story />
+        </div>
+      );
+    },
+  ],
   parameters: {
     docs: {
       title: '分隔線',
@@ -92,11 +109,6 @@ export const Default: Story = {
 export const Align: Story = {
   name: '文字對齊',
   argTypes: {
-    direction: {
-      table: {
-        disable: true,
-      },
-    },
     align: {
       table: {
         disable: true,

--- a/libs/src/ui/element/input/input.stories.tsx
+++ b/libs/src/ui/element/input/input.stories.tsx
@@ -55,7 +55,7 @@ export default {
         category: 'PROPS',
       },
     },
-    initValue: {
+    currValue: {
       description: '初始值',
       table: {
         category: 'PROPS',
@@ -141,9 +141,8 @@ export default {
     type: 'text',
     hasClear: true,
     placeholder: 'Placeholder',
-    prefix: IconComponents.SvgLock,
     size: 'medium',
-    initValue: '',
+    currValue: '',
     maxLimit: 0,
     hint: { error: '', description: 'Prompt message' },
     isDisabled: false,
@@ -155,14 +154,16 @@ type Story = StoryObj<typeof Input>;
 
 export const Default: Story = {
   name: '預設項目',
-  args: {},
+  args: {
+    prefix: <SvgAccount />,
+  },
   render(args) {
     return <Input {...args} />;
   },
 };
 
-export const InputWithStatus: Story = {
-  name: '輸入框狀態',
+export const Type: Story = {
+  name: '輸入類型',
   argTypes: {
     isDisabled: {
       table: {
@@ -175,8 +176,50 @@ export const InputWithStatus: Story = {
     docs: {
       source: {
         code: `
-<Input {...args} label="Account" />
+<Input {...args} label="Account"  prefix={<SvgAccount />} />
 <Input {...args} label="Password" type={'password'} prefix={<Lock />} />
+<Input {...args} label="Number" type="number" />
+`,
+      },
+    },
+  },
+  render(args) {
+    return (
+      <>
+        <Input
+          {...args}
+          currValue="Account"
+          label="Account"
+          type="text"
+          prefix={<SvgAccount />}
+        />
+        <Input
+          {...args}
+          currValue="Password"
+          label="Password"
+          type="password"
+          prefix={<SvgLock />}
+        />
+        <Input {...args} currValue="12345" label="Amount" type="number" />
+      </>
+    );
+  },
+};
+
+export const InputWithStatus: Story = {
+  name: '提示訊息',
+  argTypes: {
+    isDisabled: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+  args: {},
+  parameters: {
+    docs: {
+      source: {
+        code: `
 <Input {...args} label="Account" hint={{ error: 'Error message', description: '' }} />
 <Input {...args} label="Account" hint={{ error: '', description: 'Prompt message' }} />
 `,
@@ -185,14 +228,7 @@ export const InputWithStatus: Story = {
   },
   render(args) {
     return (
-      <div>
-        <Input {...args} label="Account" />
-        <Input
-          {...args}
-          label="Password"
-          type={'password'}
-          prefix={<SvgLock />}
-        />
+      <>
         <Input
           {...args}
           label="Account"
@@ -203,13 +239,7 @@ export const InputWithStatus: Story = {
           label="Account"
           hint={{ error: '', description: 'Prompt message' }}
         />
-        <Input
-          {...args}
-          label="Account"
-          isDisabled
-          hint={{ error: '', description: 'Prompt message' }}
-        />
-      </div>
+      </>
     );
   },
 };

--- a/libs/src/ui/element/input/input.tsx
+++ b/libs/src/ui/element/input/input.tsx
@@ -16,7 +16,7 @@ import { getCombinedClassName } from '@src/utils/string';
  * `InputProps` 介面定義了輸入元件的屬性。
  *
  * @property {ReactNode} [label] - 輸入框的標籤。
- * @property {string} [initValue] - 輸入框的值。
+ * @property {string} [currValue] - 輸入框的值。
  * @property {'text' | 'password' | 'email' | 'number'} type - 輸入框的類型。
  * @property {boolean} [hasClear] - 是否顯示清除按鈕。
  * @property {string} [placeholder] - 輸入框的佔位符。
@@ -34,7 +34,7 @@ export interface InputProps {
   placeholder?: string;
   prefix?: ReactNode;
   size?: 'small' | 'medium' | 'large';
-  initValue: string;
+  currValue: string;
   maxLimit?: number | undefined;
   hint?: { error: string; description: string };
   isDisabled?: boolean;
@@ -52,7 +52,7 @@ export interface InputProps {
  * @param {string} [props.placeholder='請輸入...'] - 輸入框的佔位符。
  * @param {React.ReactNode} [props.prefix] - 輸入框前綴圖標。
  * @param {string} [props.size='medium'] - 輸入框的大小。
- * @param {string} props.initValue - 輸入框的值。
+ * @param {string} props.currValue - 輸入框的值。
  * @param {Object} [props.hint={ error: '', description: '' }] - 提示信息。
  * @param {string} props.hint.error - 錯誤提示信息。
  * @param {string} props.hint.description - 描述提示信息。
@@ -69,7 +69,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
       placeholder = 'Placeholder',
       prefix = <SvgAccount />,
       size = 'medium',
-      initValue,
+      currValue,
       maxLimit = 0,
       hint = { error: '', description: '' },
       isDisabled = false,
@@ -80,7 +80,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
     ref
   ) => {
     const { inputType, value, onClear, onVisibility, handleInputChange } =
-      useInput(initValue, type, onChange);
+      useInput(currValue, type, onChange);
 
     return (
       <div className={`ded-input-container ${className}`}>

--- a/libs/src/ui/element/radio/radio.stories.tsx
+++ b/libs/src/ui/element/radio/radio.stories.tsx
@@ -19,7 +19,7 @@ export default {
         category: 'PROPS',
       },
     },
-    initValue: {
+    currValue: {
       description: '預設值',
       table: {
         category: 'PROPS',
@@ -62,7 +62,7 @@ export default {
   args: {
     dataSource: options,
     direction: 'row',
-    initValue: 'option1',
+    currValue: 'option1',
     size: 'medium',
     className: '',
     onChange: action('onChange'),

--- a/libs/src/ui/element/radio/radio.tsx
+++ b/libs/src/ui/element/radio/radio.tsx
@@ -7,7 +7,7 @@ import { getCombinedClassName } from '@src/utils/string';
  * @interface InputProps
  * @property {('primary' | 'secondary' |'neutral' | 'info' |  'success' | 'warning' | 'error')} [themeColor] - 主題顏色，可選值包括 'primary'、'secondary'、'neutral'、'success'、'warning'、'error' 和 'info'。
  * @property {{ label: string; value: string; isDisabled: boolean }[]} [dataSource] - 選項列表，每個選項包含標籤和值。
- * @property {string} [initValue] - 初始選定值。
+ * @property {string} [currValue] - 初始選定值。
  * @property {('row' | 'column')} [direction] - 排列方向，可選值包括 'row' 和 'column'。
  * @property {string} [className] - 自訂樣式類別名稱。
  * @property {(value: string) => void} [onChange] - 當選定值改變時的回調函數。
@@ -15,7 +15,7 @@ import { getCombinedClassName } from '@src/utils/string';
 export interface RadioProps {
   dataSource: { label: string; value: string; isDisabled: boolean }[];
   direction?: 'row' | 'column';
-  initValue: string;
+  currValue: string;
   size?: 'small' | 'medium' | 'large';
   className?: string;
   onChange?: (value: string) => void;
@@ -26,7 +26,7 @@ export interface RadioProps {
  * @param {Object} props - 元件的屬性。
  * @param {string} [props.themeColor='primary'] - 元件的主題顏色。
  * @param {Array} [props.options=[]] - 元件的選項列表。
- * @param {string} [props.initValue=''] - 元件的初始值。
+ * @param {string} [props.currValue=''] - 元件的初始值。
  * @param {string} [props.direction='row'] - 元件的排列方向。
  * @param {string} [props.className] - 元件的類名。
  * @param {Function} [props.onChange] - 當值發生變化時的回調函數。
@@ -34,7 +34,7 @@ export interface RadioProps {
  */
 export const Radio: React.FC<RadioProps> = ({
   dataSource,
-  initValue,
+  currValue,
   direction = 'row',
   size = 'medium',
   className = '',
@@ -43,8 +43,8 @@ export const Radio: React.FC<RadioProps> = ({
   const [currOptions, setCurrOptions] = useState<string>('');
 
   useEffect(() => {
-    setCurrOptions(initValue || '');
-  }, [initValue]);
+    setCurrOptions(currValue || '');
+  }, [currValue]);
 
   return (
     <div

--- a/libs/src/ui/element/select/select.stories.tsx
+++ b/libs/src/ui/element/select/select.stories.tsx
@@ -3,13 +3,17 @@ import { action } from '@storybook/addon-actions';
 import { Select } from '@src/ui';
 import { SvgArrowDropDown } from '@src/assets/icons';
 import { useState } from 'react';
-import { ac } from 'react-router/dist/development/route-data-aSUFWnQ6';
+import { c } from 'vite/dist/node/types.d-aGj9QkWt';
 
 const options = [
   { value: '1', label: 'Option 1' },
   { value: '2', label: 'Option 2' },
   { value: '3', label: 'Option 3' },
 ];
+
+const IconComponents = {
+  SvgArrowDropDown: <SvgArrowDropDown />,
+};
 
 export default {
   title: 'Component/Select',
@@ -36,6 +40,8 @@ export default {
     },
     suffix: {
       description: '後綴圖示',
+      options: ['SvgArrowDropDown'],
+      mapping: IconComponents,
       table: {
         category: 'PROPS',
       },

--- a/libs/src/ui/element/slider/slider.stories.tsx
+++ b/libs/src/ui/element/slider/slider.stories.tsx
@@ -49,7 +49,7 @@ export default {
         category: 'PROPS',
       },
     },
-    initValue: {
+    currValue: {
       description: '初始值',
       table: {
         category: 'PROPS',
@@ -100,7 +100,7 @@ export default {
     min: -100,
     max: 100,
     step: 1,
-    initValue: 8,
+    currValue: 8,
     label: '℃',
     isShowRange: true,
     isShowCurrValue: true,

--- a/libs/src/ui/element/slider/slider.tsx
+++ b/libs/src/ui/element/slider/slider.tsx
@@ -10,7 +10,7 @@ import React, { useState, useRef, useEffect } from 'react';
  * @property {number} [step] - 每次變動的步長。
  * @property {boolean} [isDisabled] - 是否禁用滑桿。
  * @property {string} [unit] - 值的單位。
- * @property {number} [initValue] - 初始值。
+ * @property {number} [currValue] - 初始值。
  * @property {string} [className] - 自訂樣式類名。
  * @property {(value: number) => void} [onChange] - 當值變動時的回調函數。
  */
@@ -27,7 +27,7 @@ export interface SliderProps {
   max: number;
   step?: number;
   label?: string;
-  initValue: number;
+  currValue: number;
   isShowRange?: boolean;
   isShowCurrValue?: boolean;
   isDisabled?: boolean;
@@ -46,7 +46,7 @@ export interface SliderProps {
  * @param {number} [props.max=100] - Slider 的最大值
  * @param {number} [props.step=1] - Slider 的步進值
  * @param {string} [props.unit='%'] - Slider 值的單位
- * @param {number} [props.initValue=0] - Slider 的初始值
+ * @param {number} [props.currValue=0] - Slider 的初始值
  * @param {string} [props.className] - 自定義 CSS 類名
  * @param {function} [props.onChange] - 當 Slider 值改變時的回調函數
  *
@@ -58,13 +58,13 @@ export const Slider: React.FC<SliderProps> = ({
   max = 100,
   step = 1,
   label = '',
-  initValue = 0,
+  currValue = 0,
   isShowRange = false,
   isShowCurrValue = false,
   onChange,
   className = '',
 }: SliderProps): JSX.Element => {
-  const [value, setValue] = useState<number>(initValue || min);
+  const [value, setValue] = useState<number>(currValue || min);
   const [labelPosition, setLabelPosition] = useState<number>(0);
   const [thumbPosition, setThumbPosition] = useState<number>(0);
   const rangeRef = useRef<HTMLInputElement>(null);
@@ -96,8 +96,8 @@ export const Slider: React.FC<SliderProps> = ({
   };
 
   useEffect(() => {
-    setValue(initValue);
-  }, [initValue]);
+    setValue(currValue);
+  }, [currValue]);
 
   useEffect(() => {
     updateRangeBackground(value);

--- a/libs/src/ui/element/tag/tag.tsx
+++ b/libs/src/ui/element/tag/tag.tsx
@@ -63,7 +63,7 @@ export const Tag: React.FC<TagProps> = ({
 }) => {
   return (
     <div
-      className={`ded-tag 
+      className={`ded-tag
         ${
           isDisabled
             ? getDisableClass(variant)

--- a/libs/src/ui/element/textarea/textarea.stories.tsx
+++ b/libs/src/ui/element/textarea/textarea.stories.tsx
@@ -25,7 +25,7 @@ export default {
         category: 'PROPS',
       },
     },
-    initValue: {
+    currValue: {
       description: '輸入值',
       table: {
         category: 'PROPS',
@@ -61,7 +61,7 @@ export default {
     label: 'Label',
     placeholder: 'Placeholder',
     limit: 0,
-    initValue: 'Type something',
+    currValue: 'Type something',
     hint: { error: '', description: '' },
     isDisabled: false,
     className: '',
@@ -119,8 +119,9 @@ export const TextareaStatus: Story = {
     docs: {
       source: {
         code: `
-<Textarea {...args} hint={{ error: 'Error', description: '' }} />
 <Textarea {...args} hint={{ error: '', description: 'Prompt message' }} />
+<Textarea {...args} hint={{ error: 'Error', description: '' }} />
+<Textarea {...args} isDisabled />
 `,
       },
     },
@@ -128,11 +129,12 @@ export const TextareaStatus: Story = {
   render(args) {
     return (
       <>
-        <Textarea {...args} hint={{ error: 'Error', description: '' }} />
         <Textarea
           {...args}
           hint={{ error: '', description: 'Prompt message' }}
         />
+        <Textarea {...args} hint={{ error: 'Error', description: '' }} />
+        <Textarea {...args} isDisabled />
       </>
     );
   },

--- a/libs/src/ui/element/textarea/textarea.tsx
+++ b/libs/src/ui/element/textarea/textarea.tsx
@@ -7,7 +7,7 @@ import { getHintClass, getCountClass, getBorderClass } from './styled';
  * @property {string} [label] - Textarea 的標籤。
  * @property {string} [placeholder] - Textarea 的佔位符。
  * @property {number} [limit] - 字數限制。
- * @property {string} [initValue] - 初始值。
+ * @property {string} [currValue] - 初始值。
  * @property {Object} [hint] - 提示訊息，包括錯誤訊息和描述。
  * @property {string} hint.error - 錯誤訊息。
  * @property {string} hint.description - 描述訊息。
@@ -21,7 +21,7 @@ export interface TextareaProps {
   isDisabled?: boolean;
   limit?: number;
   hint?: { error: string; description: string };
-  initValue: string;
+  currValue: string;
   className?: string;
   onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
 }
@@ -43,7 +43,7 @@ export const Textarea: React.FC<TextareaProps> = ({
   label,
   placeholder = 'Placeholder',
   limit = 30,
-  initValue,
+  currValue,
   hint = { error: '', description: '' },
   isDisabled = false,
   className = '',
@@ -52,8 +52,8 @@ export const Textarea: React.FC<TextareaProps> = ({
   const [value, setValue] = useState('');
 
   useEffect(() => {
-    setValue(initValue);
-  }, [initValue]);
+    setValue(currValue);
+  }, [currValue]);
 
   return (
     <div className={`ded-textarea-container ${className}`}>

--- a/libs/src/ui/module/avatar-group/avatar-group.tsx
+++ b/libs/src/ui/module/avatar-group/avatar-group.tsx
@@ -65,27 +65,16 @@ export const AvatarGroup: React.FC<AvatarGroupProps> = ({
         return {
           prefix: (
             <Avatar
-              size={size}
+              size="medium"
               shape="circle"
               userName={user.userName}
               caption={user.caption}
               src={user.imgSrc || ''}
             />
           ),
-          content: {
-            prefix: (
-              <Avatar
-                size="medium"
-                shape="circle"
-                userName={user.userName}
-                caption={user.caption}
-                src={user.imgSrc || ''}
-              />
-            ),
-            label: user.userName,
-            value: user.userName,
-            href: '',
-          },
+          label: user.userName,
+          value: user.userName,
+          href: '',
         };
       })
     );

--- a/libs/src/ui/module/dropdown/dropdown.stories.tsx
+++ b/libs/src/ui/module/dropdown/dropdown.stories.tsx
@@ -4,25 +4,19 @@ import { Dropdown } from '../dropdown';
 
 const options = [
   {
-    content: {
-      label: 'Option1',
-      value: 'option1',
-      // href: '#',
-    },
+    label: 'Option1',
+    value: 'option1',
+    // href: '#',
   },
   {
-    content: {
-      label: 'Option2',
-      value: 'option2',
-      // href: '#',
-    },
+    label: 'Option2',
+    value: 'option2',
+    // href: '#',
   },
   {
-    content: {
-      label: 'Option3',
-      value: 'option3',
-      // href: '#',
-    },
+    label: 'Option3',
+    value: 'option3',
+    // href: '#',
   },
 ];
 

--- a/libs/src/ui/module/dropdown/dropdown.tsx
+++ b/libs/src/ui/module/dropdown/dropdown.tsx
@@ -62,7 +62,7 @@ export const Dropdown: React.FC<DropdownProps> = ({
       >
         <Input
           size={size}
-          initValue={value}
+          currValue={value}
           isOpen={isVisible}
           type="text"
           className="ded-dropdown-input"

--- a/libs/src/ui/module/list/item.tsx
+++ b/libs/src/ui/module/list/item.tsx
@@ -13,12 +13,10 @@ import React from 'react';
  * @property {string} [className] - 項目的 CSS 類名（可選）。
  */
 export interface ItemProps {
-  content: {
-    label: string;
-    prefix?: React.ReactNode;
-    value: string;
-    href?: string;
-  };
+  label: string;
+  prefix?: React.ReactNode;
+  value: string;
+  href?: string;
   isDisabled?: boolean;
   hasDivider?: boolean;
   onClick?: (value: string) => void;
@@ -40,7 +38,10 @@ export interface ItemProps {
  * @returns {JSX.Element} 返回渲染的項目。
  */
 export const Item: React.FC<ItemProps> = ({
-  content: { label = '', prefix = '', value = '', href = '' },
+  label = '',
+  prefix = '',
+  value = '',
+  href = '',
   isDisabled = false,
   hasDivider = false,
   onClick = () => ({}),

--- a/libs/src/ui/module/list/list.stories.tsx
+++ b/libs/src/ui/module/list/list.stories.tsx
@@ -5,28 +5,22 @@ import { SvgAccount } from '@src/assets/icons';
 
 const options = [
   {
-    content: {
-      label: 'Option1',
-      value: 'option1',
-      prefix: <SvgAccount />,
-    },
+    label: 'Option1',
+    value: 'option1',
+    prefix: <SvgAccount />,
     isDisabled: true,
   },
   {
-    content: {
-      label: 'Option2',
-      value: 'option2',
-      href: '#',
-      prefix: <SvgAccount />,
-    },
+    label: 'Option2',
+    value: 'option2',
+    href: '#',
+    prefix: <SvgAccount />,
   },
   {
-    content: {
-      label: 'Option3',
-      value: 'option3',
-      href: '#',
-      prefix: <SvgAccount />,
-    },
+    label: 'Option3',
+    value: 'option3',
+    href: '#',
+    prefix: <SvgAccount />,
   },
 ];
 

--- a/libs/src/ui/module/search/search.tsx
+++ b/libs/src/ui/module/search/search.tsx
@@ -38,7 +38,7 @@ export const Search: React.FC<SearchProps> = ({
         size={size}
         type="text"
         placeholder={placeholder}
-        initValue={value}
+        currValue={value}
         prefix={<SvgSearch width={20} height={20} />}
         isDisabled={isDisabled}
         className="ded-search-input"

--- a/libs/src/ui/module/slider-control/slider-control.stories.tsx
+++ b/libs/src/ui/module/slider-control/slider-control.stories.tsx
@@ -42,7 +42,7 @@ export default {
         category: 'PROPS',
       },
     },
-    initValue: {
+    currValue: {
       description: '初始值',
       table: {
         category: 'PROPS',
@@ -117,7 +117,7 @@ export default {
     min: -100,
     max: 100,
     step: 1,
-    initValue: 8,
+    currValue: 8,
     label: '℃',
     prefix: 'Decrease',
     suffix: 'Increase',

--- a/libs/src/ui/module/slider-control/slider-control.tsx
+++ b/libs/src/ui/module/slider-control/slider-control.tsx
@@ -8,7 +8,7 @@ import { Slider, Button } from '@src/ui';
  * @property {number} [min] - 最小值。
  * @property {number} [max] - 最大值。
  * @property {number} [step] - 步長。
- * @property {number} initValue - 初始值。
+ * @property {number} currValue - 初始值。
  * @property {string} [unit] - 單位。
  * @property {React.ReactNode} [prefix] - 前綴內容。
  * @property {React.ReactNode} [suffix] - 後綴內容。
@@ -29,7 +29,7 @@ export interface SliderControlProps {
   min?: number;
   max?: number;
   step?: number;
-  initValue: number;
+  currValue: number;
   label?: string;
   prefix?: React.ReactNode;
   suffix?: React.ReactNode;
@@ -47,7 +47,7 @@ export interface SliderControlProps {
  * @param {number} [props.min=0] - 最小值
  * @param {number} [props.max=100] - 最大值
  * @param {number} [props.step=1] - 步長
- * @param {number} [props.initValue] - 初始值
+ * @param {number} [props.currValue] - 初始值
  * @param {string} [props.unit] - 單位
  * @param {React.ReactNode} [props.prefix] - 前綴
  * @param {React.ReactNode} [props.suffix] - 後綴
@@ -65,7 +65,7 @@ export const SliderControl: React.FC<SliderControlProps> = ({
   min = 0,
   max = 100,
   step = 1,
-  initValue = 0,
+  currValue = 0,
   label = '',
   isDisabled = false,
   className = '',
@@ -90,8 +90,8 @@ export const SliderControl: React.FC<SliderControlProps> = ({
   };
 
   useEffect(() => {
-    setValue(initValue);
-  }, [initValue]);
+    setValue(currValue);
+  }, [currValue]);
 
   return (
     <div className={`ded-slider-control ${className}`}>
@@ -112,7 +112,7 @@ export const SliderControl: React.FC<SliderControlProps> = ({
         isShowRange={false}
         isShowCurrValue
         isDisabled={isDisabled}
-        initValue={value}
+        currValue={value}
         onChange={handleChange}
       />
       <Button

--- a/libs/src/ui/module/toast/toast.tsx
+++ b/libs/src/ui/module/toast/toast.tsx
@@ -14,7 +14,7 @@ export interface ToastProps {
     | 'warning'
     | 'error';
   onClose?: () => void;
-  title: string;
+  title?: string;
   content: string;
   action?: ReactNode;
   prefix?: ReactNode;

--- a/libs/src/ui/section/navbar/navbar.tsx
+++ b/libs/src/ui/section/navbar/navbar.tsx
@@ -66,7 +66,7 @@ export const Navbar: React.FC<NavbarProps> = ({
             type="text"
             placeholder="Search"
             prefix={<SvgSearch width={20} height={20} />}
-            initValue={''}
+            currValue={''}
           />
         </form>
 

--- a/libs/src/ui/section/side-nav/side-nav.tsx
+++ b/libs/src/ui/section/side-nav/side-nav.tsx
@@ -230,7 +230,7 @@ export const SideNav: React.FC<SideNavProps> = ({
 
       {!isCollapsed && hasSearch && (
         <Input
-          initValue={searchValue}
+          currValue={searchValue}
           onChange={() => ({})}
           placeholder="Search..."
           prefix={<SvgSearch />}

--- a/libs/src/ui/template/auth-flow/auth-flow.stories.tsx
+++ b/libs/src/ui/template/auth-flow/auth-flow.stories.tsx
@@ -115,7 +115,7 @@ export const Default: Story = {
                 className="text-primary"
                 type="text"
                 prefix={<SvgMail />}
-                initValue=""
+                currValue=""
                 label="Email"
                 placeholder="Email"
               />
@@ -126,7 +126,7 @@ export const Default: Story = {
                 className="text-primary"
                 type="password"
                 prefix={<SvgLock />}
-                initValue=""
+                currValue=""
                 label="Password"
                 placeholder="Password"
               />
@@ -142,7 +142,7 @@ export const Default: Story = {
               </Button>
 
               <Checkbox
-                initValue={[]}
+                currValue={[]}
                 dataSource={[
                   { label: 'Remember me', value: '1', isDisabled: false },
                 ]}
@@ -217,7 +217,7 @@ export const SignUp: Story = {
                 className="text-primary"
                 type="text"
                 prefix={<SvgMail />}
-                initValue=""
+                currValue=""
                 label="Email"
                 placeholder="type email"
               />
@@ -228,7 +228,7 @@ export const SignUp: Story = {
                 className="text-primary"
                 type="password"
                 prefix={<SvgLock />}
-                initValue=""
+                currValue=""
                 label="Password"
                 placeholder="type password"
               />
@@ -239,7 +239,7 @@ export const SignUp: Story = {
                 className="text-primary"
                 type="password"
                 prefix={<SvgLock />}
-                initValue=""
+                currValue=""
                 label="Password Confirm"
                 placeholder="type password"
               />
@@ -248,7 +248,7 @@ export const SignUp: Story = {
             <Column md={12}>
               <div className="flex flex-wrap items-center">
                 <Checkbox
-                  initValue={[]}
+                  currValue={[]}
                   dataSource={[{ label: '', value: '1', isDisabled: false }]}
                 />
                 <span className="ml-1 text-neutral-600">
@@ -347,7 +347,7 @@ export const Forgot: Story = {
                 className="text-primary"
                 type="text"
                 prefix={<SvgMail />}
-                initValue=""
+                currValue=""
                 label="Email Address"
                 placeholder="type email"
                 hint={{ description: 'Description', error: '' }}
@@ -392,7 +392,7 @@ export const Verify: Story = {
                   type="text"
                   hasClear={false}
                   maxLimit={1}
-                  initValue=""
+                  currValue=""
                   className="w-[44px] h-[44px] text-center text-primary text-xl"
                   placeholder=""
                 />
@@ -400,7 +400,7 @@ export const Verify: Story = {
                   type="text"
                   hasClear={false}
                   maxLimit={1}
-                  initValue=""
+                  currValue=""
                   className="w-[44px] h-[44px] text-center text-primary text-xl"
                   placeholder=""
                 />
@@ -408,7 +408,7 @@ export const Verify: Story = {
                   type="text"
                   hasClear={false}
                   maxLimit={1}
-                  initValue=""
+                  currValue=""
                   className="w-[44px] h-[44px] text-center text-primary text-xl"
                   placeholder=""
                 />
@@ -416,7 +416,7 @@ export const Verify: Story = {
                   type="text"
                   hasClear={false}
                   maxLimit={1}
-                  initValue=""
+                  currValue=""
                   className="w-[44px] h-[44px] text-center text-primary text-xl"
                   placeholder=""
                 />
@@ -424,7 +424,7 @@ export const Verify: Story = {
                   type="text"
                   hasClear={false}
                   maxLimit={1}
-                  initValue=""
+                  currValue=""
                   className="w-[44px] h-[44px] text-center text-primary text-xl"
                   placeholder=""
                 />
@@ -433,7 +433,7 @@ export const Verify: Story = {
                   type="text"
                   hasClear={false}
                   maxLimit={1}
-                  initValue=""
+                  currValue=""
                   className="w-[44px] h-[44px] text-center text-primary text-xl"
                   placeholder=""
                 />
@@ -481,7 +481,7 @@ export const Password: Story = {
                 className="text-primary"
                 type="password"
                 prefix={<SvgLock />}
-                initValue=""
+                currValue=""
                 label="Password"
                 placeholder="type password"
               />
@@ -492,7 +492,7 @@ export const Password: Story = {
                 className="text-primary"
                 type="password"
                 prefix={<SvgLock />}
-                initValue=""
+                currValue=""
                 label="Password Confirm"
                 placeholder="type password"
               />


### PR DESCRIPTION
- Set `currValue` instead of `initValue` for the email and password inputs in the authentication flow
- Adjust the search value to be set as `currValue` rather than `initValue` to maintain consistency
- Use `currValue` for the slider control component's initial value
- Update the side nav search input to use `currValue` instead of `initValue`
- The toast component's `title` property is now optional
- Use `currValue` instead of `initValue` for the forgot password email input
- Modify the verify component inputs to use `currValue` instead of `initValue`
- Switch to `currValue` for the password and password confirm inputs in the password reset component