### PR TITLE
refactor: refine components and interface properties

### DIFF
--- a/libs/src/ui/element/divider/divider.stories.tsx
+++ b/libs/src/ui/element/divider/divider.stories.tsx
@@ -206,8 +206,8 @@ export const Width: Story = {
           const { args } = storyContext;
           return `
 <Divider {...args} type="solid">Solid</Divider>
-<Divider {...args} type="dotted">Dotted</Divider>
 <Divider {...args} type="dashed">Dashed</Divider>
+<Divider {...args} type="dotted">Dotted</Divider>
 `;
         },
       },
@@ -219,11 +219,11 @@ export const Width: Story = {
         <Divider {...args} type="solid">
           Solid
         </Divider>
-        <Divider {...args} type="dotted">
-          Dotted
-        </Divider>
         <Divider {...args} type="dashed">
           Dashed
+        </Divider>
+        <Divider {...args} type="dotted">
+          Dotted
         </Divider>
       </>
     );

--- a/libs/src/ui/element/textarea/textarea.stories.tsx
+++ b/libs/src/ui/element/textarea/textarea.stories.tsx
@@ -111,6 +111,11 @@ export const TextareaStatus: Story = {
         disable: true,
       },
     },
+    hint: {
+      table: {
+        disable: true,
+      },
+    },
   },
   args: {
     limit: 30,

--- a/libs/src/ui/module/dropdown/dropdown.stories.tsx
+++ b/libs/src/ui/module/dropdown/dropdown.stories.tsx
@@ -32,6 +32,12 @@ export default {
       },
       required: true,
     },
+    placeholder: {
+      description: '輸入提示',
+      table: {
+        category: 'PROPS',
+      },
+    },
     label: {
       description: '標籤',
       table: {
@@ -63,6 +69,7 @@ export default {
   },
   args: {
     dataSource: options,
+    placeholder: 'Placeholder',
     label: 'Label',
     size: 'medium',
     className: '',

--- a/libs/src/ui/module/dropdown/dropdown.tsx
+++ b/libs/src/ui/module/dropdown/dropdown.tsx
@@ -7,6 +7,7 @@ import { ItemProps } from '@src/ui/module/list';
 
 interface DropdownProps {
   dataSource: ItemProps[];
+  placeholder?: string;
   label?: string;
   size?: 'small' | 'medium' | 'large';
   onSelect?: (value: string) => void;
@@ -14,6 +15,7 @@ interface DropdownProps {
 }
 
 export const Dropdown: React.FC<DropdownProps> = ({
+  placeholder = 'Placeholder',
   label = '',
   size = 'medium',
   className = '',
@@ -61,6 +63,7 @@ export const Dropdown: React.FC<DropdownProps> = ({
         onClick={handleClick}
       >
         <Input
+          placeholder={placeholder}
           size={size}
           currValue={value}
           isOpen={isVisible}

--- a/libs/src/ui/module/status-indicator/status-indicator.stories.tsx
+++ b/libs/src/ui/module/status-indicator/status-indicator.stories.tsx
@@ -127,6 +127,21 @@ export const Theme: Story = {
         disable: true,
       },
     },
+    variant: {
+      table: {
+        disable: true,
+      },
+    },
+    children: {
+      table: {
+        disable: true,
+      },
+    },
+    prefix: {
+      table: {
+        disable: true,
+      },
+    },
   },
   args: {},
   render(args) {

--- a/libs/src/ui/module/toast/toast.tsx
+++ b/libs/src/ui/module/toast/toast.tsx
@@ -14,7 +14,7 @@ export interface ToastProps {
     | 'warning'
     | 'error';
   onClose?: () => void;
-  title?: string;
+  title: string;
   content: string;
   action?: ReactNode;
   prefix?: ReactNode;


### PR DESCRIPTION
- Adjust the story content for the `Width` Story component by removing and adding a `Divider` component
- Disable the `hint` table property in the `TextareaStatus` Story component
- Add the `placeholder` property with description and categorization in the `Dropdown` default export
- Update the `Dropdown` component to include a default `placeholder` value
- Modify the `Theme` Story to disable the `variant`, `children`, and `prefix` properties in the `StatusIndicator` Story component
- Update the `ToastProps` interface by making the `title` property required and removing the default value