### PR TITLE
refactor: refactor input and select components' event handling

### DIFF
--- a/libs/src/ui/element/input/input.stories.tsx
+++ b/libs/src/ui/element/input/input.stories.tsx
@@ -9,6 +9,7 @@ import {
   SvgClose,
   SvgLock,
 } from '@src/assets/icons';
+import { ChangeEvent } from 'react';
 
 const IconComponents = {
   SvgAccount: <SvgAccount />,
@@ -26,12 +27,6 @@ export default {
   argTypes: {
     label: {
       description: '標題',
-      table: {
-        category: 'PROPS',
-      },
-    },
-    name: {
-      description: '名稱',
       table: {
         category: 'PROPS',
       },
@@ -133,18 +128,6 @@ export default {
         category: 'EVENTS',
       },
     },
-    onFocus: {
-      description: '焦點事件',
-      table: {
-        category: 'EVENTS',
-      },
-    },
-    onBlur: {
-      description: '失焦事件',
-      table: {
-        category: 'EVENTS',
-      },
-    },
   },
   parameters: {
     docs: {
@@ -157,7 +140,6 @@ export default {
   args: {
     label: 'Label',
     type: 'text',
-    name: 'input',
     hasClear: true,
     placeholder: 'Placeholder',
     size: 'medium',
@@ -166,9 +148,7 @@ export default {
     hint: { error: '', description: 'Prompt message' },
     isDisabled: false,
     className: '',
-    onChange: (e: string) => action('changed')(e),
-    onFocus: (e: string) => action('focused')(e),
-    onBlur: (e: string) => action('blured')(e),
+    onChange: (e: ChangeEvent) => action('changed')(e.target),
   },
 } as Meta;
 type Story = StoryObj<typeof Input>;
@@ -179,7 +159,8 @@ export const Default: Story = {
     prefix: <SvgAccount />,
   },
   render(args) {
-    return <Input {...args} />;
+    const args2 = { test: '123', name: 'Kevin' };
+    return <Input {...args} {...args2} />;
   },
 };
 

--- a/libs/src/ui/element/input/input.tsx
+++ b/libs/src/ui/element/input/input.tsx
@@ -1,11 +1,6 @@
 import { getBorderClass, getHintClass } from './styled';
 import { getSizeClass } from '@src/utils/style';
-import {
-  ChangeEventHandler,
-  FocusEventHandler,
-  ReactNode,
-  forwardRef,
-} from 'react';
+import { ChangeEventHandler, ReactNode, forwardRef } from 'react';
 import { useInput } from '@src/hooks';
 import {
   SvgVisibility,
@@ -34,7 +29,6 @@ import { getCombinedClassName } from '@src/utils/string';
  */
 export interface InputProps {
   label?: string;
-  name?: string;
   type: 'text' | 'password' | 'email' | 'number';
   hasClear?: boolean;
   placeholder?: string;
@@ -47,8 +41,6 @@ export interface InputProps {
   isOpen?: boolean | undefined;
   className?: string;
   onChange?: ChangeEventHandler<HTMLInputElement>;
-  onFocus?: FocusEventHandler<HTMLInputElement>;
-  onBlur?: FocusEventHandler<HTMLInputElement>;
 }
 
 /**
@@ -76,7 +68,6 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
   (
     {
       label = '',
-      name = '',
       type = 'text',
       hasClear = true,
       placeholder = 'Placeholder',
@@ -89,8 +80,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
       isOpen = undefined,
       className = '',
       onChange = () => ({}),
-      onFocus = () => ({}),
-      onBlur = () => ({}),
+      ...props
     }: InputProps,
     ref
   ) => {
@@ -130,11 +120,8 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
           <input
             ref={ref}
             id="ded-input"
-            name={name}
             value={value}
             onChange={handleInputChange}
-            onFocus={onFocus}
-            onBlur={onBlur}
             type={inputType}
             className={`ded-input 
             ${getSizeClass('ded-text', size)} 
@@ -142,6 +129,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
             ${prefix ? 'ded-input-prefix' : ''}`}
             maxLength={!maxLimit ? undefined : maxLimit}
             placeholder={placeholder}
+            {...props}
           />
 
           <div className="ded-input-feat-icon">

--- a/libs/src/ui/element/select/select.stories.tsx
+++ b/libs/src/ui/element/select/select.stories.tsx
@@ -2,8 +2,7 @@ import { Meta, StoryObj } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { Select } from '@src/ui';
 import { SvgArrowDropDown } from '@src/assets/icons';
-import { useState } from 'react';
-import { c } from 'vite/dist/node/types.d-aGj9QkWt';
+import { ChangeEvent, useState } from 'react';
 
 const options = [
   { value: '1', label: 'Option 1' },
@@ -102,9 +101,9 @@ export const Default: Story = {
   render: function (args) {
     const [selectedValue, setSelectedValue] = useState<string | number>('');
 
-    const handleChange = (value: string | number) => {
-      action('onChange')(value);
-      setSelectedValue(value);
+    const handleChange = (e: ChangeEvent<HTMLSelectElement>) => {
+      action('onChange')(e.target.value);
+      setSelectedValue(e.target.value);
     };
 
     return <Select {...args} value={selectedValue} onChange={handleChange} />;

--- a/libs/src/ui/element/select/select.tsx
+++ b/libs/src/ui/element/select/select.tsx
@@ -12,7 +12,7 @@ export interface SelectProps {
   isDisabled?: boolean;
   suffix?: React.ReactNode;
   className?: string;
-  onChange?: (value: string | number) => void;
+  onChange?: (e: ChangeEvent<HTMLSelectElement>) => void;
 }
 
 export const Select: FC<SelectProps> = ({
@@ -23,11 +23,12 @@ export const Select: FC<SelectProps> = ({
   isDisabled = false,
   suffix,
   className = '',
+  ...props
 }) => {
   // 處理選擇變更
   const handleChange = (e: ChangeEvent<HTMLSelectElement>) => {
     if (onChange) {
-      onChange(e.target.value);
+      onChange(e);
     }
   };
 
@@ -38,6 +39,7 @@ export const Select: FC<SelectProps> = ({
         onChange={handleChange}
         disabled={isDisabled}
         className={`ded-select ${isDisabled ? 'ded-select-disabled' : ''}`}
+        {...props}
       >
         <option value="" disabled hidden>
           {placeholder}


### PR DESCRIPTION
- Remove unused metadata related to the `name` property in the Input story component
- Modify the `onChange` event in the Input story component to take a `ChangeEvent` parameter
- Remove unused metadata related to the `name` property in the Input component
- Modify the `onChange` event in the Input component to take a `ChangeEvent` parameter
- Modify the `onChange` event in the Select component to take a `ChangeEvent` parameter