### PR TITLE
feat: consolidate styles and dependencies across components

### DIFF
--- a/libs/src/style/component/element/_datepicker.scss
+++ b/libs/src/style/component/element/_datepicker.scss
@@ -1,5 +1,6 @@
 @use 'sass:list';
 @use '../../theme/index' as *;
+@use 'vanillajs-datepicker/css/datepicker-foundation.css';
 
 .datepicker {
   margin-top: $spacing-4;

--- a/libs/src/style/component/element/_input.scss
+++ b/libs/src/style/component/element/_input.scss
@@ -11,6 +11,7 @@
 .ded-input-group {
   width: 100%;
   height: 100%;
+  padding-inline: 0.5em;
   position: relative;
   display: flex;
   gap: $spacing-8;
@@ -23,6 +24,8 @@
   color: inherit;
   overflow: hidden;
   font-size: inherit;
+
+  container-type: 'inline-size';
 
   &:hover {
     border-width: $border-width-1;
@@ -48,7 +51,8 @@
 .ded-input {
   height: 100%;
   width: 100%;
-  padding: 0.5em 2em 0.5em 0.75em;
+  flex: 1 1 0;
+  padding-block: 0.5em;
   color: inherit;
   background-color: inherit;
   text-align: inherit;
@@ -57,13 +61,8 @@
     color: list.nth($text-placeholder, $site);
   }
 
-  &-prefix {
-    padding-left: 2.25em;
-  }
-
   &-icon {
-    position: absolute;
-    left: 0.75em;
+    width: 1em;
     color: $auo-icon-default;
 
     &-error {
@@ -77,11 +76,15 @@
 }
 
 .ded-input-feat-icon {
-  position: absolute;
-  right: 0.75em;
+  width: 1em;
   display: flex;
+  justify-content: center;
   gap: $spacing-4;
   color: $auo-icon-default;
+}
+
+.ded-input-feat-icon:has(:nth-child(2)) {
+  width: 2em;
 }
 
 .ded-input-border-error {

--- a/libs/src/ui/element/date-picker/date-picker.tsx
+++ b/libs/src/ui/element/date-picker/date-picker.tsx
@@ -1,4 +1,3 @@
-import 'vanillajs-datepicker/css/datepicker-foundation.css';
 import React, { useEffect, useRef, forwardRef, useState } from 'react';
 import { Datepicker, DateRangePicker } from 'vanillajs-datepicker';
 import { Input } from '@src/ui';

--- a/libs/src/ui/element/input/input.tsx
+++ b/libs/src/ui/element/input/input.tsx
@@ -134,47 +134,49 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
             {...props}
           />
 
-          <div className="ded-input-feat-icon">
-            {!isDisabled && hasClear && !isEmpty(value) && (
-              <div
-                onClick={onClear}
-                style={{ cursor: 'pointer' }}
-                className={`${getSizeClass('ded-icon', size)}`}
-              >
-                <SvgClose />
-              </div>
-            )}
+          {(hasClear || type === 'password') && (
+            <div className="ded-input-feat-icon">
+              {!isDisabled && hasClear && !isEmpty(value) && (
+                <div
+                  onClick={onClear}
+                  style={{ cursor: 'pointer' }}
+                  className={`${getSizeClass('ded-icon', size)}`}
+                >
+                  <SvgClose />
+                </div>
+              )}
 
-            {!isEmpty(value) && type === 'password' && (
-              <div
-                onClick={onVisibility}
-                style={{ cursor: 'pointer' }}
-                className={`${getSizeClass('ded-icon', size)}`}
-              >
-                {inputType === 'password' ? (
-                  <SvgVisibilityOff />
-                ) : (
-                  <SvgVisibility />
-                )}
-              </div>
-            )}
+              {!isEmpty(value) && type === 'password' && (
+                <div
+                  onClick={onVisibility}
+                  style={{ cursor: 'pointer' }}
+                  className={`${getSizeClass('ded-icon', size)}`}
+                >
+                  {inputType === 'password' ? (
+                    <SvgVisibilityOff />
+                  ) : (
+                    <SvgVisibility />
+                  )}
+                </div>
+              )}
 
-            {isOpen !== undefined && (
-              <div
-                onClick={onClear}
-                style={{ cursor: 'pointer' }}
-                className={`${getSizeClass('ded-icon', size)}`}
-              >
-                <SvgArrowDown
-                  width={20}
-                  height={20}
-                  className={
-                    isOpen ? 'ded-dropdown-open' : 'ded-dropdown-close'
-                  }
-                />
-              </div>
-            )}
-          </div>
+              {isOpen !== undefined && (
+                <div
+                  onClick={onClear}
+                  style={{ cursor: 'pointer' }}
+                  className={`${getSizeClass('ded-icon', size)}`}
+                >
+                  <SvgArrowDown
+                    width={20}
+                    height={20}
+                    className={
+                      isOpen ? 'ded-dropdown-open' : 'ded-dropdown-close'
+                    }
+                  />
+                </div>
+              )}
+            </div>
+          )}
         </div>
         <small
           className={`ded-input-hint ${


### PR DESCRIPTION
- Include the `vanillajs-datepicker/css/datepicker-foundation.css` in `_datepicker.scss`
- Add padding-inline to the `.ded-input-group` in `_input.scss`
- Set `container-type: 'inline-size'` in `_input.scss`
- Update styles in `.ded-input` and `.ded-input-feat-icon` in `_input.scss`
- Remove `import 'vanillajs-datepicker/css/datepicker-foundation.css';` from `date-picker.tsx`
- Add conditional rendering for clear icon in `Input` component in `input.tsx`